### PR TITLE
Switch big integer backend to ibig

### DIFF
--- a/crates/uplc/Cargo.toml
+++ b/crates/uplc/Cargo.toml
@@ -17,9 +17,10 @@ chumsky = { version = "=1.0.0-alpha.7", features = ["pratt"] }
 cryptoxide = "0.4.4"
 minicbor = { version = "0.25.1", features = ["std"] }
 once_cell = "1.20.2"
-ibig = { version = "0.3", default-features = false, features = ["std"] }
+ibig = { version = "0.3", default-features = false, features = ["num-traits", "std"] }
 secp256k1 = "0.30.0"
 thiserror = "1.0.63"
+num-traits = "0.2.19"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/crates/uplc/Cargo.toml
+++ b/crates/uplc/Cargo.toml
@@ -17,10 +17,7 @@ chumsky = { version = "=1.0.0-alpha.7", features = ["pratt"] }
 cryptoxide = "0.4.4"
 minicbor = { version = "0.25.1", features = ["std"] }
 once_cell = "1.20.2"
-rug = { version = "1.26.0", default-features = false, features = [
-    "integer",
-    "std",
-] }
+ibig = { version = "0.3", default-features = false, features = ["std"] }
 secp256k1 = "0.30.0"
 thiserror = "1.0.63"
 

--- a/crates/uplc/src/bls.rs
+++ b/crates/uplc/src/bls.rs
@@ -10,7 +10,7 @@ pub static SCALAR_PERIOD: Lazy<Integer> = Lazy::new(|| {
         0x00, 0x01,
     ];
 
-    Integer::from_digits(&bytes, rug::integer::Order::MsfBe)
+    Integer::from_be_bytes(&bytes)
 });
 
 pub const BLST_P1_COMPRESSED_SIZE: usize = 48;

--- a/crates/uplc/src/bls.rs
+++ b/crates/uplc/src/bls.rs
@@ -1,4 +1,5 @@
 use bumpalo::{collections::Vec as BumpVec, Bump};
+use ibig::{IBig, UBig};
 use once_cell::sync::Lazy;
 
 use crate::constant::Integer;
@@ -10,7 +11,7 @@ pub static SCALAR_PERIOD: Lazy<Integer> = Lazy::new(|| {
         0x00, 0x01,
     ];
 
-    Integer::from_be_bytes(&bytes)
+    Integer::from(UBig::from_be_bytes(&bytes))
 });
 
 pub const BLST_P1_COMPRESSED_SIZE: usize = 48;

--- a/crates/uplc/src/constant.rs
+++ b/crates/uplc/src/constant.rs
@@ -22,10 +22,10 @@ pub enum Constant<'a> {
     Bls12_381MlResult(&'a blst::blst_fp12),
 }
 
-pub type Integer = rug::Integer;
+pub type Integer = ibig::IBig;
 
 pub fn integer(arena: &Bump) -> &mut Integer {
-    arena.alloc(Integer::new())
+    arena.alloc(Integer::from(0))
 }
 
 pub fn integer_from(arena: &Bump, i: i128) -> &mut Integer {

--- a/crates/uplc/src/flat/data.rs
+++ b/crates/uplc/src/flat/data.rs
@@ -1,8 +1,6 @@
 use bumpalo::collections::Vec as BumpVec;
 use minicbor::data::{IanaTag, Tag};
-use rug::ops::NegAssign;
-
-use crate::data::PlutusData;
+use crate::{constant::Integer, data::PlutusData};
 
 use super::Ctx;
 
@@ -73,12 +71,10 @@ impl<'a, 'b> minicbor::decode::Decode<'b, Ctx<'a>> for &'a PlutusData<'a> {
                             bytes.extend_from_slice(chunk);
                         }
 
-                        let integer = ctx
-                            .arena
-                            .alloc(rug::Integer::from_digits(&bytes, rug::integer::Order::Msf));
+                        let integer = ctx.arena.alloc(Integer::from_be_bytes(&bytes));
 
                         if x == IanaTag::NegBignum {
-                            integer.neg_assign();
+                            *integer = -integer.clone();
                         }
 
                         Ok(PlutusData::integer(ctx.arena, integer))

--- a/crates/uplc/src/flat/data.rs
+++ b/crates/uplc/src/flat/data.rs
@@ -1,6 +1,7 @@
-use bumpalo::collections::Vec as BumpVec;
-use minicbor::data::{IanaTag, Tag};
 use crate::{constant::Integer, data::PlutusData};
+use bumpalo::collections::Vec as BumpVec;
+use ibig::UBig;
+use minicbor::data::{IanaTag, Tag};
 
 use super::Ctx;
 
@@ -71,7 +72,7 @@ impl<'a, 'b> minicbor::decode::Decode<'b, Ctx<'a>> for &'a PlutusData<'a> {
                             bytes.extend_from_slice(chunk);
                         }
 
-                        let integer = ctx.arena.alloc(Integer::from_be_bytes(&bytes));
+                        let integer = ctx.arena.alloc(Integer::from(UBig::from_be_bytes(&bytes)));
 
                         if x == IanaTag::NegBignum {
                             *integer = -integer.clone();

--- a/crates/uplc/src/flat/zigzag.rs
+++ b/crates/uplc/src/flat/zigzag.rs
@@ -2,34 +2,42 @@
 // use num_bigint::{BigInt, BigUint, ToBigInt};
 
 use crate::constant::Integer;
+use ibig::{ibig, ops::UnsignedAbs, IBig, UBig};
 
 pub trait ZigZag {
     type Zag;
 
     fn zigzag(self) -> Self::Zag;
-    fn unzigzag(self) -> Self::Zag;
+    fn unzigzag(zag: Self::Zag) -> Self;
 }
 
-impl ZigZag for &Integer {
-    type Zag = Integer;
+impl ZigZag for Integer {
+    type Zag = UBig;
 
     fn zigzag(self) -> Self::Zag {
-        if *self >= 0 {
+        if self >= ibig!(0) {
             // For non-negative numbers, just multiply by 2 (left shift by 1)
-            self.clone() << 1
+            self.clone().unsigned_abs() << 1
         } else {
             // For negative numbers: -(2 * n) - 1
             // First multiply by 2
             let double: Integer = self.clone() << 1;
 
             // Then negate and subtract 1
-            -double - 1
+            let zagged: IBig = -double - 1;
+
+            zagged.unsigned_abs()
         }
     }
 
-    fn unzigzag(self) -> Self::Zag {
-        let temp: Integer = self.clone() & 1;
+    fn unzigzag(zag: Self::Zag) -> Self {
+        let significant_bits = zag.clone() >> 1;
+        let significant_bits = IBig::from(significant_bits);
 
-        (self.clone() >> 1) ^ -(temp)
+        let exp: UBig = zag.clone() & 1;
+        let exp: i32 = exp.try_into().unwrap();
+        let exp = -exp;
+
+        significant_bits ^ exp
     }
 }

--- a/crates/uplc/src/machine/cost_model/value.rs
+++ b/crates/uplc/src/machine/cost_model/value.rs
@@ -1,3 +1,5 @@
+use ibig::ops::UnsignedAbs as _;
+use num_traits::Zero as _;
 
 use crate::{
     binder::Eval,
@@ -10,7 +12,8 @@ pub const UNIT_EX_MEM: i64 = 1;
 pub const BOOL_EX_MEM: i64 = 1;
 
 pub fn integer_ex_mem(i: &Integer) -> i64 {
-    let bits = i.abs().bit_len();
+    let bits = i.unsigned_abs().bit_len();
+
     if bits == 0 {
         1
     } else {
@@ -23,7 +26,7 @@ pub fn integer_log2(i: &Integer) -> i64 {
         return 0;
     }
 
-    i.abs().bit_len() as i64 - 1
+    i.unsigned_abs().bit_len() as i64 - 1
 }
 
 pub fn integer_log2_x(i: &Integer) -> i64 {
@@ -31,7 +34,7 @@ pub fn integer_log2_x(i: &Integer) -> i64 {
         return 0;
     }
 
-    i.abs().bit_len() as i64 - 1
+    i.unsigned_abs().bit_len() as i64 - 1
 }
 
 pub fn byte_string_ex_mem(b: &[u8]) -> i64 {
@@ -130,7 +133,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::integer_log2;
-    use ibig::IBig;
+    use ibig::{ibig, IBig};
 
     #[test]
     fn integer_log2_oracle() {
@@ -139,51 +142,31 @@ mod tests {
         assert_eq!(integer_log2(&IBig::from(1)), 0);
         assert_eq!(integer_log2(&IBig::from(42)), 5);
 
+        assert_eq!(integer_log2(&ibig!(18446744073709551615)), 63);
+        assert_eq!(integer_log2(&ibig!(999999999999999999999999999999)), 99);
         assert_eq!(
-            integer_log2(
-                IBig::from_str("18446744073709551615").unwrap()
-            ),
-            63
-        );
-        assert_eq!(
-            integer_log2(
-                IBig::from_str("999999999999999999999999999999").unwrap()
-            ),
-            99
-        );
-        assert_eq!(
-            integer_log2(
-                IBig::from_str("170141183460469231731687303715884105726").unwrap()
-            ),
+            integer_log2(&ibig!(170141183460469231731687303715884105726)),
             126
         );
         assert_eq!(
-            integer_log2(
-                IBig::from_str("170141183460469231731687303715884105727").unwrap()
-            ),
+            integer_log2(&ibig!(170141183460469231731687303715884105727)),
             126
         );
         assert_eq!(
-            integer_log2(
-                IBig::from_str("170141183460469231731687303715884105728").unwrap()
-            ),
+            integer_log2(&ibig!(170141183460469231731687303715884105728)),
             127
         );
         assert_eq!(
-            integer_log2(
-                IBig::from_str("340282366920938463463374607431768211458").unwrap()
-            ),
+            integer_log2(&ibig!(_340282366920938463463374607431768211458)),
             128
         );
         assert_eq!(
-            integer_log2(
-                IBig::from_str("999999999999999999999999999999999999999999").unwrap()
-            ),
+            integer_log2(&ibig!(_999999999999999999999999999999999999999999)),
             139
         );
         assert_eq!(
             integer_log2(
-                IBig::from_str("999999999999999999999999999999999999999999999999999999999999999999999999999999999999").unwrap()
+                &ibig!(_999999999999999999999999999999999999999999999999999999999999999999999999999999999999)
             ),
             279
         );

--- a/crates/uplc/src/machine/cost_model/value.rs
+++ b/crates/uplc/src/machine/cost_model/value.rs
@@ -1,4 +1,3 @@
-use rug::integer::BorrowInteger;
 
 use crate::{
     binder::Eval,
@@ -11,19 +10,20 @@ pub const UNIT_EX_MEM: i64 = 1;
 pub const BOOL_EX_MEM: i64 = 1;
 
 pub fn integer_ex_mem(i: &Integer) -> i64 {
-    if *i == 0 {
+    let bits = i.abs().bit_len();
+    if bits == 0 {
         1
     } else {
-        (integer_log2(i.as_abs()) / 64) + 1
+        (((bits - 1) / 64) + 1) as i64
     }
 }
 
-pub fn integer_log2(i: BorrowInteger<'_>) -> i64 {
+pub fn integer_log2(i: &Integer) -> i64 {
     if i.is_zero() {
         return 0;
     }
 
-    (i.significant_bits() - 1) as i64
+    i.abs().bit_len() as i64 - 1
 }
 
 pub fn integer_log2_x(i: &Integer) -> i64 {
@@ -31,7 +31,7 @@ pub fn integer_log2_x(i: &Integer) -> i64 {
         return 0;
     }
 
-    (i.significant_bits() - 1) as i64
+    i.abs().bit_len() as i64 - 1
 }
 
 pub fn byte_string_ex_mem(b: &[u8]) -> i64 {
@@ -130,75 +130,60 @@ mod tests {
     use std::str::FromStr;
 
     use super::integer_log2;
+    use ibig::IBig;
 
     #[test]
     fn integer_log2_oracle() {
         // Values come from the Haskell implementation
-        assert_eq!(integer_log2(rug::Integer::from(0).as_abs()), 0);
-        assert_eq!(integer_log2(rug::Integer::from(1).as_abs()), 0);
-        assert_eq!(integer_log2(rug::Integer::from(42).as_abs()), 5);
+        assert_eq!(integer_log2(&IBig::from(0)), 0);
+        assert_eq!(integer_log2(&IBig::from(1)), 0);
+        assert_eq!(integer_log2(&IBig::from(42)), 5);
 
         assert_eq!(
             integer_log2(
-                rug::Integer::from_str("18446744073709551615")
-                    .unwrap()
-                    .as_abs()
+                IBig::from_str("18446744073709551615").unwrap()
             ),
             63
         );
         assert_eq!(
             integer_log2(
-                rug::Integer::from_str("999999999999999999999999999999")
-                    .unwrap()
-                    .as_abs()
+                IBig::from_str("999999999999999999999999999999").unwrap()
             ),
             99
         );
         assert_eq!(
             integer_log2(
-                rug::Integer::from_str("170141183460469231731687303715884105726")
-                    .unwrap()
-                    .as_abs()
+                IBig::from_str("170141183460469231731687303715884105726").unwrap()
             ),
             126
         );
         assert_eq!(
             integer_log2(
-                rug::Integer::from_str("170141183460469231731687303715884105727")
-                    .unwrap()
-                    .as_abs()
+                IBig::from_str("170141183460469231731687303715884105727").unwrap()
             ),
             126
         );
         assert_eq!(
             integer_log2(
-                rug::Integer::from_str("170141183460469231731687303715884105728")
-                    .unwrap()
-                    .as_abs()
+                IBig::from_str("170141183460469231731687303715884105728").unwrap()
             ),
             127
         );
         assert_eq!(
             integer_log2(
-                rug::Integer::from_str("340282366920938463463374607431768211458")
-                    .unwrap()
-                    .as_abs()
+                IBig::from_str("340282366920938463463374607431768211458").unwrap()
             ),
             128
         );
         assert_eq!(
             integer_log2(
-                rug::Integer::from_str("999999999999999999999999999999999999999999")
-                    .unwrap()
-                    .as_abs()
+                IBig::from_str("999999999999999999999999999999999999999999").unwrap()
             ),
             139
         );
         assert_eq!(
             integer_log2(
-                rug::Integer::from_str("999999999999999999999999999999999999999999999999999999999999999999999999999999999999")
-                    .unwrap()
-                    .as_abs()
+                IBig::from_str("999999999999999999999999999999999999999999999999999999999999999999999999999999999999").unwrap()
             ),
             279
         );

--- a/crates/uplc/src/syn/constant.rs
+++ b/crates/uplc/src/syn/constant.rs
@@ -3,7 +3,6 @@ use bumpalo::{
     Bump,
 };
 use chumsky::prelude::*;
-use rug::ops::NegAssign;
 
 use crate::{
     bls::Compressable,
@@ -132,7 +131,7 @@ fn value_parser<'a>() -> impl Parser<'a, &'a str, TempConstant<'a>, Extra<'a>> {
                     let i = state.arena.alloc(Integer::from_str_radix(v, 10).unwrap());
 
                     if maybe_negative.is_some() {
-                        i.neg_assign();
+                        *i = -i.clone();
                     };
 
                     TempConstant::Integer(i)

--- a/crates/uplc/src/syn/data.rs
+++ b/crates/uplc/src/syn/data.rs
@@ -1,6 +1,5 @@
 use bumpalo::collections::Vec as BumpVec;
 use chumsky::prelude::*;
-use rug::ops::NegAssign;
 
 use crate::{constant::Integer, data::PlutusData};
 
@@ -39,7 +38,7 @@ pub fn parser<'a>() -> impl Parser<'a, &'a str, &'a PlutusData<'a>, Extra<'a>> {
                     let value = state.arena.alloc(Integer::from_str_radix(v, 10).unwrap());
 
                     if maybe_negative.is_some() {
-                        value.neg_assign();
+                        *value = -value.clone();
                     };
 
                     PlutusData::integer(state.arena, value)


### PR DESCRIPTION
## Summary
- Replace `rug` with `ibig` for big integer support
- Update runtime and parsers to use `IBig` arithmetic and byte conversions
- Compute integer bit lengths via `IBig` operations

## Testing
- `cargo test` *(failed: failed to get `clap` as a dependency; CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689e43a8e6cc8321acfb9cb7992d2d55